### PR TITLE
Adds single and cumulative binomial probability calculation functions

### DIFF
--- a/dice_roller.R
+++ b/dice_roller.R
@@ -69,6 +69,26 @@ calculate_roll_stats <- function(roll, miss = 1, hit = c(5, 6)) {
 }
 
 
+probability_of_hits <- function(hits, pool, p_hit = 2 / 6) {
+    num_comb <- ncol(combn(pool, hits))
+    # Use the binomial probability formula to calculate the
+    # probabiltity of rolling exactly the given hit amount
+    prob <- num_comb * p_hit^hits * (1 - p_hit)^(pool - hits)
+    return(prob)
+}
+
+
+cumulative_prob_of_hits <- function(hits, pool, p_hit = 2 / 6) {
+    # Calculates the individual hit results for hits <= x <= pool,
+    # giving the probability of reaching at least the given hit amount
+    probs <- vapply(hits:pool, numeric(1),
+        FUN = probability_of_hits,
+        pool = pool, p_hit = p_hit
+    )
+    return(sum(probs))
+}
+
+
 extended_test <- function(pool, target = NA) {
     pool <- as.integer(pool)
     # Prepare result matrices by making a throwaway roll


### PR DESCRIPTION
The `probability_of_hits()` function calculates the odds of getting exactly `hits` hits with the dice pool of `pool`, given the hit probability `p_hit`. 

Additionally, `cumulative_prob_of_hits()` uses the above function to calculate the probability of getting at least `hits` hits with the pool `pool`.
