### PR TITLE
Minor logic fixes

### DIFF
--- a/src/roll_logic.rs
+++ b/src/roll_logic.rs
@@ -9,7 +9,7 @@ pub fn roll(n: i32, sides: i32) -> Vec<i32> {
         roll[(roll_result - 1) as usize] += 1;
     }
 
-    roll
+    return roll
 }
 
 pub fn simple_print(res: &Vec<i32>) -> (String, String) {
@@ -61,7 +61,8 @@ fn count_hits(rolls: &Vec<i32>) -> i32 {
     for i in 4..=6 {
         count += rolls[i]
     }
-    count
+    
+    return count
 }
 
 // fn prompt(name:&str) -> String {

--- a/src/roll_logic.rs
+++ b/src/roll_logic.rs
@@ -58,7 +58,7 @@ pub fn roll_result(res: &Vec<i32>) -> ((i32, i32, i32), String) {
 
 fn count_hits(rolls: &Vec<i32>) -> i32 {
     let mut count = 0;
-    for i in 4..6 {
+    for i in 4..=6 {
         count += rolls[i]
     }
     count


### PR DESCRIPTION
the [f174929](https://github.com/nakliss/dice-roller/pull/6/commits/f17492985e58a060c205b5b315413942c5c799e7) is the most important. the `count_hits` was not counting 6s as hits.

More explanation:

https://doc.rust-lang.org/rust-by-example/flow_control/for.html

> One of the easiest ways to create an iterator is to use the range notation `a..b`. This yields values from `a` (inclusive) to `b` (exclusive) in steps of one.